### PR TITLE
HOCS-2097 Autoscale Replicas

### DIFF
--- a/kd/autoscale.yaml
+++ b/kd/autoscale.yaml
@@ -6,9 +6,9 @@ metadata:
   name: hocs-docs-converter
 spec:
   maxReplicas: 10
-  minReplicas: 1
+  minReplicas: {{.REPLICAS}}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: hocs-docs-converter
-  targetCPUUtilizationPercentage: 10
+  targetCPUUtilizationPercentage: 24


### PR DESCRIPTION
The minimum instances for a given target environment is set in the deploy script. Using this value to set the default number of minimum instances for the service.
Also changed the percentage for the converters, which is too low.