### PR TITLE
HOCS-2097 Autoscale Replicas

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -7,38 +7,39 @@ if [[ -z ${VERSION} ]] ; then
     export VERSION=${IMAGE_VERSION}
 fi
 
+if [[ ${KUBE_NAMESPACE} == *prod ]]
+then
+    export MIN_REPLICAS="2"
+    export MAX_REPLICAS="10"
+else
+    export MIN_REPLICAS="1"
+    export MAX_REPLICAS="10"
+fi
+
 if [[ ${KUBE_NAMESPACE} == "cs-prod" ]] ; then
     echo "deploy ${VERSION} to prod namespace, using HOCS_DOCS_CONVERTER_CS_PROD drone secret"
     export KUBE_TOKEN=${HOCS_DOCS_CONVERTER_CS_PROD}
-    export REPLICAS="2"
 elif [[ ${KUBE_NAMESPACE} == "wcs-prod" ]] ; then
     echo "deploy ${VERSION} to prod namespace, using HOCS_DOCS_CONVERTER_WCS_PROD drone secret"
     export KUBE_TOKEN=${HOCS_DOCS_CONVERTER_WCS_PROD}
-    export REPLICAS="2"
 elif [[ ${KUBE_NAMESPACE} == "cs-qa" ]] ; then
     echo "deploying ${VERSION} to test namespace, using HOCS_DOCS_CONVERTER_CS_QA drone secret"
     export KUBE_TOKEN=${HOCS_DOCS_CONVERTER_CS_QA}
-    export REPLICAS="2"
 elif [[ ${KUBE_NAMESPACE} == "wcs-qa" ]] ; then
     echo "deploying ${VERSION} to test namespace, using HOCS_DOCS_CONVERTER_WCS_QA drone secret"
     export KUBE_TOKEN=${HOCS_DOCS_CONVERTER_WCS_QA}
-    export REPLICAS="2"
 elif [[ ${KUBE_NAMESPACE} == "cs-demo" ]] ; then
     echo "deploy ${VERSION} to demo namespace, using HOCS_DOCS_CONVERTER_CS_DEMO drone secret"
     export KUBE_TOKEN=${HOCS_DOCS_CONVERTER_CS_DEMO}
-    export REPLICAS="1"
 elif [[ ${KUBE_NAMESPACE} == "wcs-demo" ]] ; then
     echo "deploy ${VERSION} to demo namespace, using HOCS_DOCS_CONVERTER_WCS_DEMO drone secret"
     export KUBE_TOKEN=${HOCS_DOCS_CONVERTER_WCS_DEMO}
-    export REPLICAS="1"
 elif [[ ${KUBE_NAMESPACE} == "cs-dev" ]] ; then
     echo "deploy ${VERSION} to dev namespace, using HOCS_DOCS_CONVERTER_CS_DEV drone secret"
     export KUBE_TOKEN=${HOCS_DOCS_CONVERTER_CS_DEV}
-    export REPLICAS="1"
 elif [[ ${KUBE_NAMESPACE} == "wcs-dev" ]] ; then
     echo "deploy ${VERSION} to dev namespace, using HOCS_DOCS_CONVERTER_WCS_DEV drone secret"
     export KUBE_TOKEN=${HOCS_DOCS_CONVERTER_WCS_DEV}
-    export REPLICAS="1"
 else
     echo "Unable to find environment: ${ENVIRONMENT}"
 fi

--- a/kd/autoscale.yaml
+++ b/kd/autoscale.yaml
@@ -5,8 +5,8 @@ metadata:
     app: hocs-docs-converter
   name: hocs-docs-converter
 spec:
-  maxReplicas: 10
-  minReplicas: {{.REPLICAS}}
+  maxReplicas: {{.MAX_REPLICAS}}
+  minReplicas: {{.MIN_REPLICAS}}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     version: {{.VERSION}}
 spec:
-  replicas: {{.REPLICAS}}
+  replicas: {{.MIN_REPLICAS}}
   selector:
     matchLabels:
       name: hocs-docs-converter


### PR DESCRIPTION
Maximum replicas have been added to the autoscaler.
The value is set in the deploy script along with the minimum replicas.
Max replicas set to 10 as this service does not have a database connection and requires many instances to process document conversions.